### PR TITLE
ci: enable npm caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org'
+        cache: npm
 
     - name: Install Dependencies
       run: npm ci


### PR DESCRIPTION
## Summary

- Add npm caching to actions/setup-node step

## Benefits

This will speed up CI runs by caching node_modules between workflow runs, reducing install times and improving developer experience.

## Test plan

- [x] Verified workflow syntax is valid
- [ ] CI workflows will run faster on subsequent runs after this merge